### PR TITLE
Add Tkinter correlation heatmap application

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,204 +1,71 @@
-# CorrelHeatmap - Stock Correlation Analysis System
+# Correlation Heatmap Builder
 
-A professional-grade correlation analysis system for stock tickers, built with institutional-quality Python architecture and designed for scalable quantitative research.
+A desktop application for exploring the historical correlations between equity tickers. Enter a
+portfolio, download end-of-day prices from Yahoo Finance (via `yfinance`), and visualise the
+correlation matrix as a colour-coded Tkinter canvas.
 
-## 🎯 Project Overview
+## Features
 
-This system provides sophisticated correlation analysis capabilities for stock portfolios, enabling:
-- Dynamic correlation matrix computation across multiple timeframes
-- Interactive heatmap visualizations
-- Risk assessment and portfolio optimization insights
-- Integration with Interactive Brokers (IBKR) API for real-time data
-- Institutional-grade data handling and analysis
+- Pure-Python correlation engine requiring only the standard library for analysis
+- Optional integration with `yfinance` to download daily adjusted closes
+- Custom Tkinter canvas heatmap with numeric overlays and tabular output
+- Supports log or percentage return calculations and enforces simple input validation
 
-## 🏗️ Architecture
+## Getting Started
 
-### Core Components
-- **Data Layer**: Robust data ingestion and preprocessing
-- **Analysis Engine**: Statistical correlation computations
-- **Visualization**: Interactive heatmaps and correlation matrices
-- **Risk Management**: Portfolio risk metrics and alerts
-- **API Integration**: IBKR connectivity for live market data
+### 1. Create a virtual environment
 
-### Design Principles
-- **Scalability**: Built to handle large portfolios and high-frequency data
-- **Modularity**: Clean separation of concerns with dependency injection
-- **Performance**: Optimized for institutional-scale computations
-- **Reliability**: Comprehensive error handling and logging
-- **Maintainability**: Type hints, documentation, and testing
-
-## 🚀 Quick Start
-
-### Prerequisites
-- Python 3.9+
-- IBKR TWS/Gateway running (for live data)
-- Required Python packages (see requirements.txt)
-
-### Installation
 ```bash
-# Clone the repository
-git clone <repository-url>
-cd CorrelHeatmap
+python -m venv .venv
+source .venv/bin/activate  # On Windows use: .venv\Scripts\activate
+```
 
-# Create virtual environment
-python -m venv venv
-source venv/bin/activate  # On Windows: venv\Scripts\activate
+### 2. Install dependencies
 
-# Install dependencies
+```bash
 pip install -r requirements.txt
-
-# Set up configuration
-cp config/config.example.yaml config/config.yaml
-# Edit config.yaml with your IBKR credentials and preferences
 ```
 
-### Basic Usage
-```python
-from correlheatmap import CorrelationAnalyzer
-from correlheatmap.data import IBKRDataProvider
+> `yfinance` pulls in `pandas` and other dependencies needed for data retrieval. The analytical code
+> itself does not rely on external libraries.
 
-# Initialize data provider
-data_provider = IBKRDataProvider(config_path="config/config.yaml")
+### 3. Launch the Tkinter app
 
-# Create analyzer
-analyzer = CorrelationAnalyzer(
-    data_provider=data_provider,
-    tickers=["AAPL", "MSFT", "GOOGL", "TSLA", "NVDA"],
-    timeframe="1Y"
-)
-
-# Generate correlation matrix
-correlation_matrix = analyzer.compute_correlation()
-
-# Create interactive heatmap
-analyzer.visualize_heatmap(correlation_matrix)
+```bash
+python app.py
 ```
 
-## 📊 Features
+Enter ticker symbols (comma or space separated), configure the date range and return calculation,
+then press **Build heatmap**. The app fetches daily prices, computes overlapping return series, and
+displays the resulting correlation matrix both numerically and as a colour map.
 
-### Correlation Analysis
-- **Multiple Timeframes**: Daily, weekly, monthly correlations
-- **Rolling Correlations**: Dynamic correlation tracking over time
-- **Statistical Significance**: P-values and confidence intervals
-- **Regime Detection**: Identify correlation regime changes
+## Running Tests
 
-### Visualization
-- **Interactive Heatmaps**: Zoom, pan, and hover for detailed insights
-- **Time Series Plots**: Correlation evolution over time
-- **Portfolio Risk Metrics**: VaR, CVaR, and correlation-based risk measures
-- **Export Capabilities**: High-resolution charts for presentations
+A small pytest suite verifies the return and correlation calculations and the colour mapping logic:
 
-### Data Management
-- **Multiple Data Sources**: IBKR, Yahoo Finance, Alpha Vantage
-- **Data Validation**: Automated data quality checks
-- **Caching**: Intelligent caching for performance optimization
-- **Real-time Updates**: Live correlation monitoring
+```bash
+pytest
+```
 
-## 🛠️ Development
+## Project Structure
 
-### Project Structure
 ```
 CorrelHeatmap/
+├── app.py                 # Tkinter user interface and heatmap renderer
+├── requirements.txt       # Optional runtime dependencies
 ├── src/
-│   ├── correlheatmap/
-│   │   ├── core/           # Core analysis engine
-│   │   ├── data/           # Data providers and handlers
-│   │   ├── visualization/  # Plotting and visualization
-│   │   ├── risk/          # Risk management tools
-│   │   └── utils/          # Utility functions
-│   └── tests/             # Comprehensive test suite
-├── config/                # Configuration files
-├── notebooks/             # Jupyter notebooks for research
-├── docs/                  # Documentation
-└── scripts/               # Utility scripts
+│   └── correlheatmap/
+│       ├── __init__.py
+│       ├── analysis.py    # Pure Python return/correlation calculations
+│       ├── data.py        # Optional yfinance data loader
+│       └── visualization.py  # Colour utilities for the heatmap
+└── tests/                 # Pytest unit tests
 ```
 
-### Testing
-```bash
-# Run all tests
-pytest
+## Notes
 
-# Run with coverage
-pytest --cov=correlheatmap
-
-# Run specific test categories
-pytest tests/unit/
-pytest tests/integration/
-```
-
-### Code Quality
-```bash
-# Format code
-black src/
-isort src/
-
-# Lint code
-flake8 src/
-mypy src/
-
-# Security scan
-bandit -r src/
-```
-
-## 📈 Trading Applications
-
-### Portfolio Construction
-- Identify uncorrelated assets for diversification
-- Optimize portfolio weights based on correlation structure
-- Monitor correlation breakdowns for rebalancing signals
-
-### Risk Management
-- Real-time correlation monitoring
-- Stress testing under correlation regime changes
-- Dynamic hedging strategies based on correlation patterns
-
-### Research Applications
-- Sector rotation analysis
-- Market regime identification
-- Cross-asset correlation studies
-
-## 🔧 Configuration
-
-### IBKR Setup
-1. Install TWS or IB Gateway
-2. Enable API connections in TWS settings
-3. Configure port and client ID in config.yaml
-4. Test connection with provided utilities
-
-### Data Sources
-- **Primary**: Interactive Brokers (real-time, historical)
-- **Backup**: Yahoo Finance, Alpha Vantage
-- **Custom**: Add your own data providers
-
-## 📚 Documentation
-
-- [API Reference](docs/api.md)
-- [Configuration Guide](docs/configuration.md)
-- [Trading Strategies](docs/strategies.md)
-- [Performance Optimization](docs/performance.md)
-
-## 🤝 Contributing
-
-This project follows institutional development standards:
-
-1. **Code Review**: All changes require peer review
-2. **Testing**: Maintain >90% test coverage
-3. **Documentation**: Update docs for all new features
-4. **Performance**: Benchmark critical paths
-5. **Security**: Regular security audits
-
-## 📄 License
-
-Proprietary - Internal Trading Research Tool
-
-## ⚠️ Disclaimer
-
-This software is for research and educational purposes only. Past performance does not guarantee future results. Always conduct thorough backtesting and risk assessment before deploying any trading strategies.
-
-## 📞 Support
-
-For technical issues or feature requests, please contact the development team or create an issue in the project repository.
-
----
-
-*Built with institutional-grade Python for serious quantitative research.*
+- Network access is required for live data downloads. If you are working offline, you can populate a
+  `PriceHistory` dictionary manually and call `compute_correlation_matrix` directly.
+- Heatmap colours follow a blue (negative) to red (positive) gradient with white representing zero
+  correlation. Values are clamped to the [-1, 1] interval.
+- Tkinter is part of the Python standard library, so no additional GUI framework is required.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,177 @@
+"""Tkinter-based correlation heatmap builder."""
+
+from __future__ import annotations
+
+import tkinter as tk
+from datetime import date, datetime, timedelta
+from tkinter import messagebox, ttk
+from typing import List
+
+from correlheatmap.analysis import CorrelationResult, compute_correlation_matrix
+from correlheatmap.data import fetch_daily_closes
+from correlheatmap.visualization import correlation_to_hex
+
+DEFAULT_LOOKBACK_DAYS = 365
+CELL_SIZE = 70
+LABEL_OFFSET = 90
+FONT = ("Helvetica", 11)
+
+
+class HeatmapApp:
+    def __init__(self, master: tk.Tk) -> None:
+        self.master = master
+        self.master.title("Correlation Heatmap Builder")
+        self.master.geometry("900x700")
+
+        self.tickers_var = tk.StringVar(value="AAPL, MSFT, GOOGL, NVDA")
+        today = date.today()
+        self.start_var = tk.StringVar(value=(today - timedelta(days=DEFAULT_LOOKBACK_DAYS)).isoformat())
+        self.end_var = tk.StringVar(value=today.isoformat())
+        self.return_var = tk.StringVar(value="log")
+
+        self._build_controls()
+        self._build_results_area()
+
+    def _build_controls(self) -> None:
+        controls = ttk.Frame(self.master, padding=10)
+        controls.pack(side=tk.TOP, fill=tk.X)
+
+        ttk.Label(controls, text="Tickers (comma separated):").grid(row=0, column=0, sticky=tk.W)
+        ttk.Entry(controls, textvariable=self.tickers_var, width=50).grid(row=0, column=1, sticky=tk.W)
+
+        ttk.Label(controls, text="Start date (YYYY-MM-DD):").grid(row=1, column=0, sticky=tk.W)
+        ttk.Entry(controls, textvariable=self.start_var, width=20).grid(row=1, column=1, sticky=tk.W)
+
+        ttk.Label(controls, text="End date (YYYY-MM-DD):").grid(row=2, column=0, sticky=tk.W)
+        ttk.Entry(controls, textvariable=self.end_var, width=20).grid(row=2, column=1, sticky=tk.W)
+
+        ttk.Label(controls, text="Return type:").grid(row=3, column=0, sticky=tk.W)
+        ttk.Combobox(
+            controls,
+            textvariable=self.return_var,
+            values=("log", "pct"),
+            width=5,
+            state="readonly",
+        ).grid(row=3, column=1, sticky=tk.W)
+
+        ttk.Button(controls, text="Build heatmap", command=self.build_heatmap).grid(row=0, column=2, rowspan=2, padx=10)
+
+        for i in range(3):
+            controls.rowconfigure(i, pad=5)
+        controls.columnconfigure(1, weight=1)
+
+    def _build_results_area(self) -> None:
+        results = ttk.Frame(self.master, padding=(10, 0, 10, 10))
+        results.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
+
+        self.canvas = tk.Canvas(results, background="white", width=600, height=400)
+        self.canvas.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
+
+        self.table = ttk.Treeview(results, show="headings", height=5)
+        self.table.pack(side=tk.TOP, fill=tk.X, pady=10)
+
+        self.status_var = tk.StringVar(value="Enter tickers and click 'Build heatmap'.")
+        ttk.Label(results, textvariable=self.status_var).pack(side=tk.TOP, anchor=tk.W)
+
+    def build_heatmap(self) -> None:
+        tickers = self._parse_tickers(self.tickers_var.get())
+        if len(tickers) < 2:
+            messagebox.showerror("Validation error", "Enter at least two ticker symbols.")
+            return
+
+        start_date = self._parse_date(self.start_var.get(), "start")
+        end_date = self._parse_date(self.end_var.get(), "end")
+        if start_date is None or end_date is None:
+            return
+        if start_date >= end_date:
+            messagebox.showerror("Validation error", "Start date must be earlier than end date.")
+            return
+
+        try:
+            price_history = fetch_daily_closes(tickers, start=start_date, end=end_date)
+        except Exception as exc:
+            messagebox.showerror("Data error", f"Unable to download prices: {exc}")
+            return
+
+        try:
+            result = compute_correlation_matrix(price_history, return_type=self.return_var.get())
+        except ValueError as exc:
+            messagebox.showerror("Analysis error", str(exc))
+            return
+
+        self.status_var.set(
+            f"Computed correlations using {result.observation_count} overlapping daily returns."
+        )
+        self._render_heatmap(result)
+        self._render_table(result)
+
+    def _render_heatmap(self, result: CorrelationResult) -> None:
+        tickers = result.tickers
+        size = CELL_SIZE
+        offset = LABEL_OFFSET
+        width = offset + size * len(tickers)
+        height = offset + size * len(tickers)
+        self.canvas.config(width=width, height=height)
+        self.canvas.delete("all")
+
+        for idx, ticker in enumerate(tickers):
+            x = offset + idx * size + size / 2
+            y = offset / 2
+            self.canvas.create_text(x, y, text=ticker, angle=90, font=FONT)
+            self.canvas.create_text(offset / 2, offset + idx * size + size / 2, text=ticker, font=FONT)
+
+        for row_idx, row in enumerate(result.matrix):
+            for col_idx, value in enumerate(row):
+                x0 = offset + col_idx * size
+                y0 = offset + row_idx * size
+                x1 = x0 + size
+                y1 = y0 + size
+                colour = correlation_to_hex(value)
+                self.canvas.create_rectangle(x0, y0, x1, y1, fill=colour, outline="white")
+                self.canvas.create_text(
+                    (x0 + x1) / 2,
+                    (y0 + y1) / 2,
+                    text=f"{value:.2f}",
+                    font=FONT,
+                )
+
+    def _render_table(self, result: CorrelationResult) -> None:
+        tickers = result.tickers
+        columns = ["Ticker"] + tickers
+        self.table.configure(columns=columns)
+        for column in columns:
+            anchor = "w" if column == "Ticker" else "center"
+            width = 120 if column == "Ticker" else 80
+            self.table.heading(column, text=column if column != "Ticker" else "")
+            self.table.column(column, width=width, anchor=anchor)
+
+        for row in self.table.get_children():
+            self.table.delete(row)
+
+        for ticker, values in zip(tickers, result.matrix):
+            formatted = [f"{value:.2f}" for value in values]
+            self.table.insert("", tk.END, values=[ticker] + formatted)
+
+    @staticmethod
+    def _parse_tickers(raw: str) -> List[str]:
+        parts = [item.strip().upper() for item in raw.replace("\n", " ").replace(",", " ").split()]
+        return [item for item in parts if item]
+
+    @staticmethod
+    def _parse_date(raw: str, label: str) -> date | None:
+        try:
+            parsed = datetime.strptime(raw.strip(), "%Y-%m-%d").date()
+        except ValueError:
+            messagebox.showerror("Validation error", f"Invalid {label} date: {raw}")
+            return None
+        return parsed
+
+
+def main() -> None:
+    root = tk.Tk()
+    HeatmapApp(root)
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = src

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+yfinance>=0.2
+pandas>=1.5
+pytest>=7.4

--- a/src/correlheatmap/__init__.py
+++ b/src/correlheatmap/__init__.py
@@ -1,0 +1,15 @@
+"""Correlation heatmap tools."""
+
+from .analysis import CorrelationResult, compute_correlation_matrix, compute_returns
+from .data import PriceHistory, PricePoint, fetch_daily_closes
+from .visualization import correlation_to_hex
+
+__all__ = [
+    "CorrelationResult",
+    "PriceHistory",
+    "PricePoint",
+    "compute_correlation_matrix",
+    "compute_returns",
+    "fetch_daily_closes",
+    "correlation_to_hex",
+]

--- a/src/correlheatmap/analysis.py
+++ b/src/correlheatmap/analysis.py
@@ -1,0 +1,119 @@
+"""Pure-Python correlation calculations for price history data."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from math import isclose, log, sqrt
+from statistics import mean
+from typing import Dict, List, Sequence, Tuple
+
+from .data import PriceHistory, PricePoint
+
+ReturnPoint = Tuple[date, float]
+
+
+@dataclass
+class CorrelationResult:
+    tickers: List[str]
+    matrix: List[List[float]]
+    observation_count: int
+
+
+def compute_returns(series: Sequence[PricePoint], *, return_type: str = "log") -> List[ReturnPoint]:
+    """Compute daily returns from a time-ordered price series."""
+
+    if len(series) < 2:
+        raise ValueError("At least two price observations are required to compute returns.")
+
+    if return_type not in {"log", "pct"}:
+        raise ValueError("Return type must be 'log' or 'pct'.")
+
+    ordered = sorted(series, key=lambda item: item[0])
+    returns: List[ReturnPoint] = []
+
+    previous_date, previous_price = ordered[0]
+    for current_date, current_price in ordered[1:]:
+        if previous_price <= 0 or current_price <= 0:
+            previous_date, previous_price = current_date, current_price
+            continue
+        if return_type == "log":
+            value = log(current_price / previous_price)
+        else:
+            value = (current_price - previous_price) / previous_price
+        returns.append((current_date, value))
+        previous_date, previous_price = current_date, current_price
+
+    if not returns:
+        raise ValueError("Unable to compute returns due to non-positive prices or insufficient data.")
+    return returns
+
+
+def _align_returns(
+    price_history: PriceHistory, *, return_type: str = "log"
+) -> Tuple[List[str], List[List[float]]]:
+    ticker_returns: Dict[str, Dict[date, float]] = {}
+    for ticker, series in price_history.items():
+        returns = compute_returns(series, return_type=return_type)
+        ticker_returns[ticker] = {obs_date: value for obs_date, value in returns}
+
+    tickers = sorted(ticker_returns.keys())
+    if len(tickers) < 2:
+        raise ValueError("At least two tickers are required to compute correlations.")
+
+    common_dates = set.intersection(*(set(values.keys()) for values in ticker_returns.values()))
+    if len(common_dates) < 2:
+        raise ValueError("Not enough overlapping return observations across tickers.")
+
+    sorted_dates = sorted(common_dates)
+    matrix: List[List[float]] = []
+    for obs_date in sorted_dates:
+        row = [ticker_returns[ticker][obs_date] for ticker in tickers]
+        matrix.append(row)
+
+    return tickers, matrix
+
+
+def compute_correlation_matrix(
+    price_history: PriceHistory,
+    *,
+    return_type: str = "log",
+) -> CorrelationResult:
+    """Compute a correlation matrix from ``PriceHistory`` data."""
+
+    tickers, matrix = _align_returns(price_history, return_type=return_type)
+    n_observations = len(matrix)
+    if n_observations < 2:
+        raise ValueError("Not enough return observations to compute correlation.")
+
+    columns = list(zip(*matrix))
+    means = [mean(column) for column in columns]
+    stdevs = [
+        sqrt(sum((value - column_mean) ** 2 for value in column) / (n_observations - 1))
+        for column, column_mean in zip(columns, means)
+    ]
+
+    correlation_matrix: List[List[float]] = []
+    for i in range(len(tickers)):
+        row: List[float] = []
+        for j in range(len(tickers)):
+            if i == j:
+                row.append(1.0)
+                continue
+
+            std_i, std_j = stdevs[i], stdevs[j]
+            if isclose(std_i, 0.0) or isclose(std_j, 0.0):
+                row.append(0.0)
+                continue
+
+            covariance = sum(
+                (matrix[k][i] - means[i]) * (matrix[k][j] - means[j]) for k in range(n_observations)
+            ) / (n_observations - 1)
+            correlation = covariance / (std_i * std_j)
+            row.append(max(-1.0, min(1.0, correlation)))
+        correlation_matrix.append(row)
+
+    return CorrelationResult(tickers=tickers, matrix=correlation_matrix, observation_count=n_observations)
+
+
+__all__ = ["CorrelationResult", "compute_returns", "compute_correlation_matrix"]

--- a/src/correlheatmap/data.py
+++ b/src/correlheatmap/data.py
@@ -1,0 +1,67 @@
+"""Utilities for retrieving historical price data."""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Dict, Iterable, List, Sequence, Tuple
+
+PricePoint = Tuple[date, float]
+PriceHistory = Dict[str, List[PricePoint]]
+
+
+def _normalise_tickers(tickers: Iterable[str]) -> List[str]:
+    seen: set[str] = set()
+    cleaned: List[str] = []
+    for ticker in tickers:
+        symbol = ticker.strip().upper()
+        if symbol and symbol not in seen:
+            cleaned.append(symbol)
+            seen.add(symbol)
+    return cleaned
+
+
+def fetch_daily_closes(
+    tickers: Sequence[str],
+    *,
+    start: date | None = None,
+    end: date | None = None,
+) -> PriceHistory:
+    """Download daily adjusted closing prices via the optional :mod:`yfinance` dependency."""
+
+    normalised = _normalise_tickers(tickers)
+    if not normalised:
+        raise ValueError("At least one ticker symbol must be provided.")
+
+    try:
+        import yfinance as yf  # type: ignore
+    except ImportError as exc:  # pragma: no cover - exercised only when dependency missing at runtime
+        raise ImportError(
+            "The 'yfinance' package is required to download market data. Install it with 'pip install yfinance'."
+        ) from exc
+
+    history: PriceHistory = {}
+    for symbol in normalised:
+        data = yf.download(  # type: ignore[attr-defined]
+            symbol,
+            start=start,
+            end=end,
+            progress=False,
+            auto_adjust=True,
+            actions=False,
+            interval="1d",
+        )
+        if data.empty:
+            continue
+
+        closes = []
+        for index, value in data["Close"].items():  # type: ignore[index]
+            closes.append((index.date(), float(value)))
+        if closes:
+            history[symbol] = closes
+
+    if not history:
+        raise ValueError("No price data was retrieved for the requested tickers.")
+    return history
+
+
+__all__ = ["fetch_daily_closes", "PriceHistory", "PricePoint"]

--- a/src/correlheatmap/visualization.py
+++ b/src/correlheatmap/visualization.py
@@ -1,0 +1,29 @@
+"""Colour utilities for rendering correlation heatmaps on a Tkinter canvas."""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+NEGATIVE_COLOUR = (33, 102, 172)  # Deep blue
+NEUTRAL_COLOUR = (247, 247, 247)  # Light grey
+POSITIVE_COLOUR = (178, 24, 43)   # Deep red
+
+
+def _interpolate_colour(start: Tuple[int, int, int], end: Tuple[int, int, int], fraction: float) -> str:
+    fraction = max(0.0, min(1.0, fraction))
+    red = int(start[0] + (end[0] - start[0]) * fraction + 0.5)
+    green = int(start[1] + (end[1] - start[1]) * fraction + 0.5)
+    blue = int(start[2] + (end[2] - start[2]) * fraction + 0.5)
+    return f"#{red:02x}{green:02x}{blue:02x}"
+
+
+def correlation_to_hex(value: float) -> str:
+    """Map a correlation value in [-1, 1] to a colour hex code."""
+
+    clamped = max(-1.0, min(1.0, value))
+    if clamped >= 0:
+        return _interpolate_colour(NEUTRAL_COLOUR, POSITIVE_COLOUR, clamped)
+    return _interpolate_colour(NEGATIVE_COLOUR, NEUTRAL_COLOUR, 1.0 + clamped)
+
+
+__all__ = ["correlation_to_hex"]

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import pytest
+
+from correlheatmap.analysis import CorrelationResult, compute_correlation_matrix, compute_returns
+from correlheatmap.data import PriceHistory
+
+
+def make_price_series(start: date, prices: list[float]) -> list[tuple[date, float]]:
+    return [(start + timedelta(days=i), price) for i, price in enumerate(prices)]
+
+
+def test_compute_returns_log() -> None:
+    series = make_price_series(date(2024, 1, 1), [100.0, 110.0, 121.0])
+    returns = compute_returns(series, return_type="log")
+    assert len(returns) == 2
+    assert pytest.approx(returns[0][1], rel=1e-9) == 0.0953101798
+    assert pytest.approx(returns[1][1], rel=1e-9) == 0.0953101798
+
+
+def test_compute_returns_pct() -> None:
+    series = make_price_series(date(2024, 1, 1), [50.0, 55.0, 60.5])
+    returns = compute_returns(series, return_type="pct")
+    assert [round(value, 4) for _, value in returns] == [0.1, 0.1]
+
+
+def test_compute_correlation_matrix_basic() -> None:
+    history: PriceHistory = {
+        "AAA": make_price_series(date(2024, 1, 1), [100, 102, 104, 103, 105]),
+        "BBB": make_price_series(date(2024, 1, 1), [50, 51, 52, 51, 53]),
+        "CCC": make_price_series(date(2024, 1, 1), [200, 198, 202, 205, 207]),
+    }
+    result = compute_correlation_matrix(history, return_type="pct")
+    assert isinstance(result, CorrelationResult)
+    assert result.tickers == ["AAA", "BBB", "CCC"]
+    assert result.observation_count == 4
+    assert result.matrix[0][0] == pytest.approx(1.0)
+    assert result.matrix[1][1] == pytest.approx(1.0)
+    assert result.matrix[2][2] == pytest.approx(1.0)
+    assert -1.0 <= result.matrix[0][1] <= 1.0
+
+
+def test_compute_correlation_requires_two_tickers() -> None:
+    history: PriceHistory = {"AAA": make_price_series(date(2024, 1, 1), [100, 101, 102])}
+    with pytest.raises(ValueError):
+        compute_correlation_matrix(history)
+
+
+def test_compute_returns_requires_positive_prices() -> None:
+    series = make_price_series(date(2024, 1, 1), [100.0, 0.0, 120.0])
+    with pytest.raises(ValueError):
+        compute_returns(series)

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from correlheatmap.visualization import correlation_to_hex
+
+
+def test_correlation_to_hex_range() -> None:
+    assert correlation_to_hex(-1.0) == "#2166ac"
+    assert correlation_to_hex(1.0) == "#b2182b"
+    assert correlation_to_hex(0.0) == "#f7f7f7"
+
+
+def test_correlation_to_hex_clamps_values() -> None:
+    assert correlation_to_hex(-2.0) == "#2166ac"
+    assert correlation_to_hex(2.0) == "#b2182b"


### PR DESCRIPTION
## Summary
- replace the placeholder project with a working Tkinter-based correlation heatmap application
- implement a pure-Python correlation engine, optional yfinance data loader, and colour utilities
- add pytest coverage for return calculations, correlation assembly, and colour mapping and refresh the README

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d06f79a22c83209856e47573ba0892